### PR TITLE
Made more generic / reusable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-out
+/out/
+/release/

--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,27 @@ run:
 	
 build:
 	go build -o ./out/gnome-dav-support .
+
+build-amd64:
+	GOOS=linux GOARCH=amd64 go build -o ./out/gnome-dav-support .
+
+build-arm:
+	GOOS=linux GOARCH=arm go build -o ./out/gnome-dav-support .
+
+clean:
+	rm -rf ./out
+
+clean-release: clean
+	rm -rf ./release
+
+release-arm: clean build-arm
+	mkdir --parent ./release
+	cp ./install.sh ./out
+	zip --junk-paths ./release/gnome-dav-support-arm.zip ./out/*
+
+release-amd64: clean build-amd64
+	mkdir --parent ./release
+	cp ./install.sh ./out
+	zip --junk-paths ./release/gnome-dav-support-amd64.zip ./out/*
+
+release: clean-release release-amd64 release-arm

--- a/README.md
+++ b/README.md
@@ -7,15 +7,26 @@ Gnome's online account integration doesn't support standalone CalDAV and CardDAV
 
 I'm using it with self hosted Radicale but it can be used with Fastmail or any other DAV implementation.
 
-Shame on Gnome for not supporting open standards even when they have already done all the work and implemented it in another place. 
-
 ## How to use it ?
 
-* add your dav server url in serviceMap in `main.go` and point to it in the redirect func
-* `make build`
-* make a systemd service to run this permanently
-* add a new nextcloud account in Gnome Online Accounts, and set url as `localhost:8223`, and your dav server username and password in required fields.
+Install a Go development environment. Then:
 
+```bash
+git clone https://github.com/IceWreck/Gnome-DAV-Support-Shim.git
+cd Gnome-DAV-Support-Shim
+make build
+install.sh
+```
+
+Then add a new NextCloud account in Gnome Online Accounts. Set the URL to `http://localhost:8223`, and your dav server username and password in required fields.
+
+The install script sets up a systemd service that starts when you log in. It defaults to Fastmail. You can specify custom DAV URLs like so:
+
+```bash
+install.sh --cal https://dav.abifog.com/IceWreck --card https://dav.abifog.com/IceWreck
+```
+
+To uninstall, run `install.sh --uninstall`.
 
 ## An alternative method
 

--- a/README.md
+++ b/README.md
@@ -9,22 +9,27 @@ I'm using it with self hosted Radicale but it can be used with Fastmail or any o
 
 ## How to use it ?
 
-Install a Go development environment. Then:
-
 ```bash
-git clone https://github.com/IceWreck/Gnome-DAV-Support-Shim.git
-cd Gnome-DAV-Support-Shim
-make build
-install.sh
+# Assuming you're on an amd64 system (ARM is also supported):
+wget https://github.com/pcrockett/Gnome-DAV-Support-Shim/releases/download/v1.0/gnome-dav-support-amd64.zip
+unzip gnome-dav-support-amd64.zip
 ```
 
-Then add a new NextCloud account in Gnome Online Accounts. Set the URL to `http://localhost:8223`, and your dav server username and password in required fields.
-
-The install script sets up a systemd service that starts when you log in. It defaults to Fastmail. You can specify custom DAV URLs like so:
+Now simply run the install script, which sets up a systemd service that starts when you log in. If you are using Fastmail:
 
 ```bash
-install.sh --cal https://dav.abifog.com/IceWreck --card https://dav.abifog.com/IceWreck
+./install.sh
 ```
+
+... or if you're using a different Cal/CardDAV service, run something to this effect:
+
+```bash
+./install.sh --cal "${caldav-service-url}" --card "${carddav-service-url}"
+```
+
+_Note: There is no need for `sudo`._
+
+Then add a new NextCloud account in Gnome Online Accounts. Set the URL to `http://localhost:8223`, and your DAV server username and password in required fields.
 
 To uninstall, run `install.sh --uninstall`.
 

--- a/install.sh
+++ b/install.sh
@@ -101,7 +101,13 @@ function install_service() {
     test -d "${SYSTEMD_UNIT_DIR}" || mkdir --parent "${SYSTEMD_UNIT_DIR}"
     test -d "${BIN_DIR}" || mkdir --parent "${BIN_DIR}"
 
-    cp "${SCRIPT_DIR}/out/gnome-dav-support" "${BIN_DIR}"
+    if [ -f "${SCRIPT_DIR}/out/gnome-dav-support" ]; then
+        cp "${SCRIPT_DIR}/out/gnome-dav-support" "${BIN_DIR}"
+    elif [ -f "${SCRIPT_DIR}/gnome-dav-support" ]; then
+        cp "${SCRIPT_DIR}/gnome-dav-support" "${BIN_DIR}"
+    else
+        panic "Unable to find gnome-dav-support executable. Try running \`make build\` first."
+    fi
 
     (cat <<EOF
 [Unit]

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+[[ "${BASH_VERSINFO[0]}" -lt 4 ]] && echo "Bash >= 4 required" && exit 1
+
+function show_usage() {
+    cat >&2 << EOF
+Usage: ${SCRIPT_NAME} [OPTION...]
+  --cal           Specify the CalDAV URL to use
+  --card          Specify the CardDAV URL to use
+  -u, --uninstall Uninstall the service
+  -h, --help      Show this help message then exit
+EOF
+}
+
+SCRIPT_DIR=$(dirname "$(readlink -f "${0}")")
+readonly SCRIPT_DIR
+
+SCRIPT_NAME=$(basename "${0}")
+readonly SCRIPT_NAME
+
+readonly SERVICE_NAME="gnome-dav-shim"
+readonly BIN_DIR=~/.local/bin
+readonly BIN_FILE="${BIN_DIR}/gnome-dav-support"
+readonly SYSTEMD_UNIT_DIR=~/.config/systemd/user
+readonly SYSTEMD_UNIT_FILE="${SYSTEMD_UNIT_DIR}/${SERVICE_NAME}.service"
+
+function panic() {
+    >&2 echo "FATAL: ${*}"
+    exit 1
+}
+
+ARG_CAL="fastmail"
+ARG_CARD="fastmail"
+
+function parse_commandline() {
+
+    while [ "${#}" -gt "0" ]; do
+        local consume=1
+
+        case "${1}" in
+            --cal)
+                test "${#}" -ge 2 || panic "Missing CalDAV URL / provider"
+                ARG_CAL="${2}"
+                consume=2
+            ;;
+            --card)
+                test "${#}" -ge 2 || panic "Missing CardDAV URL / provider"
+                ARG_CARD="${2}"
+                consume=2
+            ;;
+            -u|--uninstall)
+                ARG_UNINSTALL="true"
+            ;;
+            -h|-\?|--help)
+                ARG_HELP="true"
+            ;;
+            *)
+                >&2 echo "Unrecognized argument: ${1}"
+                show_usage
+                exit 1
+            ;;
+        esac
+
+        shift ${consume}
+    done
+}
+
+parse_commandline "${@}"
+
+if [ "${ARG_HELP:-}" = "true" ]; then
+    show_usage
+    exit 0
+fi
+
+function unexpected_error() {
+
+    local line_num="${1}"
+    local script_path="${2}"
+    local faulting_command="${3}"
+    
+    cat <<EOF
+Unexpected error at line ${line_num} ${script_path}:
+    Command: "${faulting_command}"
+EOF
+
+}
+
+trap 'unexpected_error ${LINENO} ${BASH_SOURCE[0]} ${BASH_COMMAND}' ERR   # Single-quotes are important, see https://unix.stackexchange.com/a/39660
+
+test "$(id --user)" -ne 0 || echo "WARNING: This script is being run as root; that may not be what you want."
+
+function service_exists() {
+    systemctl list-unit-files --full --type=service --user \
+        | grep --fixed-strings "${SERVICE_NAME}.service" > /dev/null
+}
+
+function install_service() {
+
+    service_exists && panic "Service is already installed."
+
+    test -d "${SYSTEMD_UNIT_DIR}" || mkdir --parent "${SYSTEMD_UNIT_DIR}"
+    test -d "${BIN_DIR}" || mkdir --parent "${BIN_DIR}"
+
+    cp "${SCRIPT_DIR}/out/gnome-dav-support" "${BIN_DIR}"
+
+    (cat <<EOF
+[Unit]
+Description=GNOME DAV support shim
+Wants=network.target
+After=network-online.target
+
+[Service]
+ExecStart=${BIN_DIR}/gnome-dav-support --cal "${ARG_CAL}" --card "${ARG_CARD}"
+Restart=always
+
+[Install]
+WantedBy=default.target
+EOF
+    ) > "${SYSTEMD_UNIT_FILE}"
+
+    systemctl daemon-reload --user
+    systemctl enable --user --now "${SERVICE_NAME}"
+}
+
+function uninstall_service() {
+
+    service_exists || panic "Service is not installed yet."
+
+    if systemctl is-active --user "${SERVICE_NAME}" > /dev/null; then
+        systemctl stop --user "${SERVICE_NAME}"
+    fi
+
+    if systemctl is-enabled --user "${SERVICE_NAME}" > /dev/null; then
+        systemctl disable --user "${SERVICE_NAME}"
+    fi
+
+    test -f "${SYSTEMD_UNIT_FILE}" && rm "${SYSTEMD_UNIT_FILE}"
+    test -f "${BIN_FILE}" && rm "${BIN_FILE}"
+
+    systemctl --user daemon-reload
+}
+
+function main() {
+    if [ "${ARG_UNINSTALL:-}" = "true" ]; then
+        uninstall_service
+    else
+        install_service
+    fi
+}
+
+main

--- a/main.go
+++ b/main.go
@@ -12,12 +12,12 @@ import (
 var calDavUrl string
 var cardDavUrl string
 
-var wellKnownCardDav = map[string]string {
+var wellKnownCardDav = map[string]string{
 	"fastmail": "https://carddav.fastmail.com/dav/addressbooks",
 	// Can add more services here, pull requests welcome
 }
 
-var wellKnownCalDav = map[string]string {
+var wellKnownCalDav = map[string]string{
 	"fastmail": "https://caldav.fastmail.com/dav/calendars",
 	// Can add more services here, pull requests welcome
 }
@@ -37,14 +37,14 @@ func main() {
 	flag.Parse()
 
 	wkCal, exists := wellKnownCalDav[calDavArg]
-	if (exists) {
+	if exists {
 		calDavUrl = wkCal
 	} else {
 		calDavUrl = calDavArg
 	}
 
 	wkCard, exists := wellKnownCardDav[cardDavArg]
-	if (exists) {
+	if exists {
 		cardDavUrl = wkCard
 	} else {
 		cardDavUrl = cardDavArg

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"net/http"
 
@@ -8,11 +9,17 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 )
 
-var serviceMap = map[string]string{
-	"radicale-caldav":  "https://dav.abifog.com/IceWreck",
-	"radicale-carddav": "https://dav.abifog.com/IceWreck",
-	"fastmail-caldav":  "https://caldav.fastmail.com/dav/calendars",
-	"fastmail-carddav": "https://carddav.fastmail.com/dav/addressbooks",
+var calDavUrl string
+var cardDavUrl string
+
+var wellKnownCardDav = map[string]string {
+	"fastmail": "https://carddav.fastmail.com/dav/addressbooks",
+	// Can add more services here, pull requests welcome
+}
+
+var wellKnownCalDav = map[string]string {
+	"fastmail": "https://caldav.fastmail.com/dav/calendars",
+	// Can add more services here, pull requests welcome
 }
 
 func init() {
@@ -20,6 +27,28 @@ func init() {
 }
 
 func main() {
+
+	var calDavArg string
+	var cardDavArg string
+
+	flag.StringVar(&calDavArg, "cal", "fastmail", "The CalDAV redirect URL")
+	flag.StringVar(&cardDavArg, "card", "fastmail", "The CardDAV redirect URL")
+
+	flag.Parse()
+
+	wkCal, exists := wellKnownCalDav[calDavArg]
+	if (exists) {
+		calDavUrl = wkCal
+	} else {
+		calDavUrl = calDavArg
+	}
+
+	wkCard, exists := wellKnownCardDav[cardDavArg]
+	if (exists) {
+		cardDavUrl = wkCard
+	} else {
+		cardDavUrl = cardDavArg
+	}
 
 	r := chi.NewRouter()
 	r.Use(middleware.Logger)
@@ -40,9 +69,9 @@ func redirect(w http.ResponseWriter, r *http.Request) {
 	davType := chi.URLParam(r, "davType")
 	switch davType {
 	case "caldav":
-		http.Redirect(w, r, serviceMap["radicale-caldav"], http.StatusTemporaryRedirect)
+		http.Redirect(w, r, calDavUrl, http.StatusTemporaryRedirect)
 	case "carddav":
-		http.Redirect(w, r, serviceMap["radicale-carddav"], http.StatusTemporaryRedirect)
+		http.Redirect(w, r, cardDavUrl, http.StatusTemporaryRedirect)
 	default:
 		w.Write([]byte("Not Implemented Yet"))
 	}


### PR DESCRIPTION
First of all, this is a great solution to the lack of GNOME DAV support. I was thinking I'd like to use this without changing the source. If you were wanting to keep this a small personal project for yourself with hard-coded values, no worries. Just close the PR and I'll be fine.

Summary of what I've done:

1. Created command line arguments `-cal` and `-card` to allow for custom URLs.
2. For well-known services like Fastmail, you can just use "fastmail" for these arguments. If no arguments are specified, it defaults to Fastmail. I also added a convenient place in the code for people to add more well-known URLs to the code via pull requests.
3. Created an install script that sets up a systemd service so the shim starts automatically on login.
4. Created a "release" section in the makefile that bundles everything up into releasable zip files.
5. Updated readme with steps on how to use it.

Disclaimer: I'm not a Go developer (yet).